### PR TITLE
Add SignalBridgeService skeleton

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,11 @@
                 android:label="Access to TextSecure Secrets"
                 android:protectionLevel="signature" />
 
+    <!-- Permission required to bind to SignalBridgeService -->
+    <permission android:name="org.thoughtcrime.securesms.ACCESS_BRIDGE"
+                android:label="Access to SignalBridgeService"
+                android:protectionLevel="signature" />
+
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
     <uses-feature android:name="android.hardware.location" android:required="false"/>
@@ -1215,6 +1220,11 @@
         android:name=".service.BackupProgressService"
         android:foregroundServiceType="dataSync"
         android:exported="false"/>
+
+    <service
+        android:name=".service.SignalBridgeService"
+        android:exported="true"
+        android:permission="org.thoughtcrime.securesms.ACCESS_BRIDGE"/>
 
     <service
         android:name=".gcm.FcmFetchBackgroundService"

--- a/app/src/main/java/org/thoughtcrime/securesms/service/SignalBridgeService.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/SignalBridgeService.java
@@ -1,0 +1,93 @@
+package org.thoughtcrime.securesms.service;
+
+import android.app.Service;
+import android.content.Intent;
+import android.database.Cursor;
+import android.os.Binder;
+import android.os.IBinder;
+
+import androidx.annotation.Nullable;
+
+import org.signal.core.util.logging.Log;
+import org.thoughtcrime.securesms.database.MessageTable;
+import org.thoughtcrime.securesms.database.SignalDatabase;
+import org.thoughtcrime.securesms.mms.OutgoingMessage;
+import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.sms.MessageSender;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Simple service that exposes basic APIs for sending and retrieving messages
+ * so that other applications can interact with Signal.
+ */
+public class SignalBridgeService extends Service {
+
+    private static final String TAG = Log.tag(SignalBridgeService.class);
+
+    private final IBinder binder = new BridgeBinder();
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return binder;
+    }
+
+    public class BridgeBinder extends Binder {
+
+        public SignalBridgeService getService() {
+            return SignalBridgeService.this;
+        }
+
+        /**
+         * Send a plain text message to the given recipient. The identifier may be
+         * a phone number in E164 format or a UUID.
+         */
+        public void sendMessage(String recipientIdentifier, String body) {
+            Recipient recipient = Recipient.external(recipientIdentifier);
+            if (recipient == null) {
+                Log.w(TAG, "Unable to parse recipient: " + recipientIdentifier);
+                return;
+            }
+
+            OutgoingMessage outgoing = OutgoingMessage.text(recipient, body, 0);
+            MessageSender.send(SignalBridgeService.this, outgoing, -1,
+                               MessageSender.SendType.SIGNAL, null, null);
+        }
+
+        /**
+         * Return the most recent text bodies for the given recipient.
+         */
+        public List<String> getRecentMessages(String recipientIdentifier, int limit) {
+            Recipient recipient = Recipient.external(recipientIdentifier);
+            if (recipient == null) {
+                Log.w(TAG, "Unable to parse recipient: " + recipientIdentifier);
+                return new ArrayList<>();
+            }
+
+            long threadId = SignalDatabase.threads().getOrCreateThreadIdFor(recipient);
+
+            Cursor cursor = SignalDatabase.messages().getReadableDatabase()
+                    .query(MessageTable.TABLE_NAME,
+                           new String[]{MessageTable.BODY},
+                           MessageTable.THREAD_ID + "=?",
+                           new String[]{String.valueOf(threadId)},
+                           null,
+                           null,
+                           MessageTable.DATE_RECEIVED + " DESC",
+                           String.valueOf(limit));
+
+            List<String> messages = new ArrayList<>(limit);
+            try {
+                int column = cursor.getColumnIndexOrThrow(MessageTable.BODY);
+                while (cursor.moveToNext()) {
+                    messages.add(cursor.getString(column));
+                }
+            } finally {
+                cursor.close();
+            }
+            return messages;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create binder for `SignalBridgeService` with basic message send and fetch operations
- register `SignalBridgeService` in the manifest
- add `ACCESS_BRIDGE` permission and require it to bind to the service

## Testing
- `./gradlew format` *(fails: unsupported Kotlin plugin version)*
- `./gradlew test` *(fails: unsupported Kotlin plugin version)*

------
https://chatgpt.com/codex/tasks/task_e_6840136efb6c832c9409f265fe2490a8